### PR TITLE
fixup errors that occur post-repository2016

### DIFF
--- a/src/main/java/io/fixprotocol/orchestra2proto/ProtoGen.java
+++ b/src/main/java/io/fixprotocol/orchestra2proto/ProtoGen.java
@@ -48,7 +48,7 @@ public class ProtoGen {
 	{
 		Repository rootElement = null;
 		ValidationEventCollector evHandler = new JAXBValidator();
-		JAXBContext jc = JAXBContext.newInstance("io.fixprotocol._2016.fixrepository");
+		JAXBContext jc = JAXBContext.newInstance("io.fixprotocol._2020.orchestra.repository");
 		Unmarshaller unmarshaller = jc.createUnmarshaller();
 		unmarshaller.setEventHandler(evHandler);
 		FileInputStream fis = new FileInputStream(repoFileName);


### PR DESCRIPTION
@donmendelson, *thank you* for this utility.  Being familiar with the quality of your work, I was thrilled to find out that it exists! I apologize in advance that my questions and/or proposed fixes in this PR could likely be answered by reading the complete orchestra spec...

Problem: I could not get orchestra2proto to run w/o errors

Solution: I switched the imports from `_2016` to `_2020`, ensured that GroupRefType is considered before ComponentRefType (because GroupRefType `is-a` ComponentRefType), and defaulted to using the `value` attr when the `sort` attr is not present.

Observations/Questions:

- Does a correct orchestra file ever omit `sort`?  This util assumes not.
- Does `sort` ever differ from `value`?  This PR assumes that if `sort` is omitted, then `value` should be used.
- CodeType `Suspend` has a `sort` of ` 4` (i.e. with a space).  I assume this is a typo in `OrchestraFIXLatest.xml`.
- What I'm really going for is FIX Latest, so I'm not sure the `_2020` package is the right thing.