### PR TITLE
Adds Group Component Generation and Quality of Life Changes

### DIFF
--- a/src/main/java/io/fixprotocol/orchestra2proto/CapnpModelFactory.java
+++ b/src/main/java/io/fixprotocol/orchestra2proto/CapnpModelFactory.java
@@ -399,13 +399,13 @@ public class CapnpModelFactory extends ModelFactory {
 			}
 			else if(field.getType().equals("Qty")) {
 				protoField.name = getFieldName(fieldRef);
-				protoField.typeName = "Decimal32"; // this will depend on enc attrs
+				protoField.typeName = "Decimal64"; // this will depend on enc attrs
 				protoField.scalarOrEnumOrMsg = MessageField.ScalarOrEnumOrMsg.ProtoMsg;
 				protoField.isRepeating = false;
 			}
 			else if(field.getType().equals("Price")) {
 				protoField.name = getFieldName(fieldRef);
-				protoField.typeName = "Decimal32"; // this will depend on enc attrs
+				protoField.typeName = "Decimal64"; // this will depend on enc attrs
 				protoField.scalarOrEnumOrMsg = MessageField.ScalarOrEnumOrMsg.ProtoMsg;
 				protoField.isRepeating = false;
 			}

--- a/src/main/java/io/fixprotocol/orchestra2proto/CapnpModelFactory.java
+++ b/src/main/java/io/fixprotocol/orchestra2proto/CapnpModelFactory.java
@@ -611,7 +611,7 @@ public class CapnpModelFactory extends ModelFactory {
 			if(unionType == UnionDataTypeT.QTY) {
 				protoField = new MessageField();
 				protoField.name = getFieldName(fieldRef) + unionType.value();
-				protoField.typeName = "Decimal32";
+				protoField.typeName = "Decimal64";
 				protoField.scalarOrEnumOrMsg = MessageField.ScalarOrEnumOrMsg.ProtoMsg;
 				protoField.isRepeating = false;
 			}

--- a/src/main/java/io/fixprotocol/orchestra2proto/ProtobufModelFactory.java
+++ b/src/main/java/io/fixprotocol/orchestra2proto/ProtobufModelFactory.java
@@ -651,7 +651,7 @@ public class ProtobufModelFactory extends ModelFactory {
 				if(unionType == UnionDataTypeT.QTY) {
 					protoField = new MessageField();
 					protoField.fieldName = toProtoFieldName(getFieldName(fieldRef) + unionType.value());
-					protoField.typeName = "Decimal32";
+					protoField.typeName = "Decimal64";
 					protoField.scalarOrEnumOrMsg = MessageField.ScalarOrEnumOrMsg.ProtoMsg;
 					protoField.isRepeating = false;
 				}

--- a/src/main/java/io/fixprotocol/orchestra2proto/ProtobufModelFactory.java
+++ b/src/main/java/io/fixprotocol/orchestra2proto/ProtobufModelFactory.java
@@ -437,13 +437,13 @@ public class ProtobufModelFactory extends ModelFactory {
 				}
 				else if(field.getType().equals("Qty")) {
 					protoField.fieldName = toProtoFieldName(getFieldName(fieldRef));
-					protoField.typeName = "Decimal32"; // this will depend on enc attrs
+					protoField.typeName = "Decimal64"; // this will depend on enc attrs
 					protoField.scalarOrEnumOrMsg = MessageField.ScalarOrEnumOrMsg.ProtoMsg;
 					protoField.isRepeating = false;
 				}
 				else if(field.getType().equals("Price")) {
 					protoField.fieldName = toProtoFieldName(getFieldName(fieldRef));
-					protoField.typeName = "Decimal32"; // this will depend on enc attrs
+					protoField.typeName = "Decimal64"; // this will depend on enc attrs
 					protoField.scalarOrEnumOrMsg = MessageField.ScalarOrEnumOrMsg.ProtoMsg;
 					protoField.isRepeating = false;
 				}

--- a/src/main/java/io/fixprotocol/orchestra2proto/ProtobufModelFactory.java
+++ b/src/main/java/io/fixprotocol/orchestra2proto/ProtobufModelFactory.java
@@ -890,7 +890,8 @@ public class ProtobufModelFactory extends ModelFactory {
 					"FIX_5_0",
 					"FIXT_1_1",
 					"FIX_5_0SP1",
-					"FIX_5_0SP2"
+					"FIX_5_0SP2",
+					"FIX_LATEST"
 			);
 			Enum protoEnum = new Enum();
 			String codeSetName = "Version"; // mock-up a code set name so we can build like the other enums.

--- a/src/main/java/io/fixprotocol/orchestra2proto/ProtobufModelFactory.java
+++ b/src/main/java/io/fixprotocol/orchestra2proto/ProtobufModelFactory.java
@@ -139,13 +139,7 @@ public class ProtobufModelFactory extends ModelFactory {
 		List<CodeSetType> codeSetTypes = codeSets.getCodeSet();
 		for(CodeSetType codeSetType : codeSetTypes) {
 			Enum protoEnum = buildEnum(codeSetType);
-			if(codeSetCategoryMap.containsKey(codeSetType.getName())) {
-				String pkgName = codeSetCategoryMap.get(codeSetType.getName());
-				protoEnum.homePackage = pkgName;
-			}
-			else {
-				protoEnum.homePackage = null;
-			}
+			protoEnum.homePackage = codegenSettings.useAltOutputPackaging ? "supporting-messages" : "fix";
 			protoSchema.enums.add(protoEnum);
 		}
 		/*

--- a/src/main/java/io/fixprotocol/orchestra2proto/ProtobufModelFactory.java
+++ b/src/main/java/io/fixprotocol/orchestra2proto/ProtobufModelFactory.java
@@ -216,6 +216,12 @@ public class ProtobufModelFactory extends ModelFactory {
 				EnumField f = new EnumField();
 				f.fieldName = toProtoEnumFieldName(codeSet.getName(), codeType.getName());
 				f.fieldNum = Integer.parseInt(sort); // for now
+
+				// "UNSPECIFIED" is a reserved default enum value for the generated protos, must make value unique
+				if(f.fieldName.contains("_UNSPECIFIED")) {
+					f.fieldName = f.fieldName + "_VALUE";
+				}
+
 				if(codeType.getAdded() != null) {
 					String added = toVersionFieldName(codeType.getAdded());
 					f.fieldOptions.add(new Option("enum_added", added, Option.ValueType.ENUM_LITERAL));
@@ -227,6 +233,8 @@ public class ProtobufModelFactory extends ModelFactory {
 				if(codeType.getDeprecated() != null) {
 					String s = toVersionFieldName(codeType.getDeprecated());
 					f.fieldOptions.add(new Option("enum_deprecated", s, Option.ValueType.ENUM_LITERAL));
+					// Deprecations may cause enum value duplication for the generated protos, must make values unique
+					f.fieldName = f.fieldName + "_DEPRECATED";
 				}
 				if(codeType.getValue() != null) {
 					String s = codeType.getValue();


### PR DESCRIPTION
This PR is adding the missing support for Group generation for the generated protos.  It also some includes some quality of life changes that ensures the generated protos can be use with protoc for generated source files in various languages

- Adds the generation of Groups to proto files
- Fixes Enum Duplications that can occur on a deprecated enum and unspecified enum by including a suffix
- Adds FIX Latest enum option to the FIX Version Enum
- Moves common message item processing logic to single private method to reduce maintenance and potential bug spots by changing one spot and not the other
- Moves all generated enums into fix.proto file (or alternate package when defined) to remove all circular references inside the generated protos